### PR TITLE
introduce ${git_protocol} for html project

### DIFF
--- a/CMake/Herc60_CreateTargets.cmake
+++ b/CMake/Herc60_CreateTargets.cmake
@@ -409,7 +409,7 @@ endif( )
 
 externalproject_add( html
         SOURCE_DIR        ${PROJECT_BINARY_DIR}/html
-        GIT_REPOSITORY    "git://github.com/hercules-390/html"
+        GIT_REPOSITORY    "${git_protocol}//github.com/hercules-390/html"
         GIT_TAG           "gh-pages"
         CONFIGURE_COMMAND ""        # No Configure
         BUILD_COMMAND ""            # No build


### PR DESCRIPTION
GitHub has revoked git: as git protocol due to safety reasons.
The local build with Ninja or Unix Make Files breaks without this change